### PR TITLE
Flask+Gunicorn, Docker, Caching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+client_id=ab12
+client_secret=cd34
+refresh_token=xyz123
+dt_bot_username=jobautomator
+REFRESH_HOUR=0
+LOG_LEVEL=WARNING

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
 client_id=ab12
 client_secret=cd34
 refresh_token=xyz123
-dt_bot_username=jobautomator
-REFRESH_HOUR=0
-LOG_LEVEL=WARNING

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 variables.env*
 env/
 __pycache__/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,16 @@ FROM python:slim
 # Create a working directory
 WORKDIR /app
 
-# Copy your redirect script into the container
-COPY dt_redirect.py /app/dt_redirect.py
+COPY requirements.txt /app/requirements.txt
 
-# Install PRAW (and any other needed packages)
-RUN pip install --no-cache-dir praw
+# Install requirements
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy redirect script into the container
+COPY dt_redirect.py /app/dt_redirect.py
 
 # Expose port 8080
 EXPOSE 8080
 
-# Start your Python script
-CMD ["python", "dt_redirect.py"]
+# Run via Gunicorn (what a name)
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "dt_redirect:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use a lightweight Python base image
+FROM python:slim
+
+# Create a working directory
+WORKDIR /app
+
+# Copy your redirect script into the container
+COPY dt_redirect.py /app/dt_redirect.py
+
+# Install PRAW (and any other needed packages)
+RUN pip install --no-cache-dir praw
+
+# Expose port 8080
+EXPOSE 8080
+
+# Start your Python script
+CMD ["python", "dt_redirect.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY dt_redirect.py /app/dt_redirect.py
 EXPOSE 8080
 
 # Run via Gunicorn (what a name)
-CMD ["gunicorn", "--bind", "0.0.0.0:8080", "dt_redirect:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "dt_redirect:app", "--workers=2"]

--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ any change to the DT, this script must also be updated.
 In case no DT is found, users are redirected to the subreddit itself.
 
 I've also included the associated NGINX configuration file.
+
+Supports the following trailing arguments in the URL path
+
+/dt/compact - returns i.reddit.com instead of www. - which reddit seems to internally redirect to www anyway now, so I'm not sure if this is useful
+
+/dt/stream - returns a reddit-stream.com url
+
+/dt/old - returns old.reddit.com instead of www
+
+---
+
+To run in docker: `docker compose up -d --build` (remove `-d` if you don't want to fork it to the background)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ I've also included the associated NGINX configuration file.
 
 Supports the following trailing arguments in the URL path
 
-/dt/compact - returns i.reddit.com instead of www. - which reddit seems to internally redirect to www anyway now, so I'm not sure if this is useful
-
 /dt/stream - returns a reddit-stream.com url
 
 /dt/old - returns old.reddit.com instead of www

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+---
+services:
+  dt-redirect:
+    build: .
+    ports:
+      - '8080:8080'
+    env_file:
+      - .env

--- a/dt_redirect.py
+++ b/dt_redirect.py
@@ -1,54 +1,165 @@
-"""A simple webserver for redirecting traffic to latest discussion thread"""
-
-from http.server import HTTPServer, BaseHTTPRequestHandler
+import time
+import logging
 import os
-
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from datetime import datetime, timedelta, timezone
 import praw
 
+# ---------------------------------------------------------------
+# Setup Logging
+# ---------------------------------------------------------------
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "WARNING").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.WARNING),
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------
+# We'll search the public subreddit /r/neoliberal for recent posts (last 36 hours).
+# Then we check if they are by jobautomator, containing "Discussion Thread".
+DISCUSSION_AUTHOR = os.environ.get("DISCUSSION_AUTHOR", "jobautomator")
+DISCUSSION_SUBREDDIT = os.environ.get("DISCUSSION_SUBREDDIT", "neoliberal")
+
+# We'll keep a simple cache to avoid hitting Reddit's API on every request.
+CACHE = {
+    "dt_url": None,             # The last known Discussion Thread URL
+    "cached_at": 0.0,           # When we last fetched it (Unix timestamp)
+}
+
+# 36 hours in seconds
+TIME_WINDOW_SECONDS = 36 * 3600
+
+# We'll say once we fetch, we won't refetch for another X seconds (e.g., 15 min).
+CACHE_TTL = 15 * 60  # 15 minutes
+
+
+def find_recent_discussion_thread() -> str:
+    """
+    Search /r/neoliberal for posts from the last 36 hours,
+    posted by DISCUSSION_AUTHOR, containing 'Discussion Thread' in the title.
+
+    Returns:
+        str: The URL of the most recent matching post,
+             or fallback to https://www.reddit.com/r/neoliberal if none is found.
+    """
+    logger.info("Searching subreddit for Discussion Thread...")
+
+    # We'll figure out the cutoff time in Unix seconds
+    cutoff = time.time() - TIME_WINDOW_SECONDS
+
+    try:
+        subreddit = reddit.subreddit(DISCUSSION_SUBREDDIT)
+
+        # We fetch up to 100 newest submissions to see if there's a match
+        # (Adjust limit if needed)
+        matches = []
+        for submission in subreddit.new(limit=100):
+            # If the post is older than 36 hours, no need to consider it
+            if submission.created_utc < cutoff:
+                continue
+
+            # Check if author & title match
+            if (
+                submission.author
+                and submission.author.name.lower() == DISCUSSION_AUTHOR.lower()
+                and "discussion thread" in submission.title.lower()
+            ):
+                matches.append(submission)
+
+        # Sort matched posts by creation time descending
+        matches.sort(key=lambda s: s.created_utc, reverse=True)
+
+        if matches:
+            # The first item is the most recent match
+            most_recent = matches[0]
+            logger.info(
+                f"Found a Discussion Thread by u/{DISCUSSION_AUTHOR}: "
+                f"'{most_recent.title}' -> {most_recent.url} "
+                f"(created_utc={most_recent.created_utc})"
+            )
+            return most_recent.url
+        else:
+            logger.warning("No matching Discussion Thread found in the last 36 hours.")
+            return f"https://www.reddit.com/r/{DISCUSSION_SUBREDDIT}"
+    except Exception as e:
+        logger.exception(f"Failed to search the subreddit. Using fallback. Error: {e}")
+        return f"https://www.reddit.com/r/{DISCUSSION_SUBREDDIT}"
+
+
+def get_discussion_thread_url() -> str:
+    """
+    Return a cached Discussion Thread URL if fresh,
+    otherwise fetch it from Reddit using find_recent_discussion_thread().
+    """
+    now = time.time()
+    # Check if our cache is still fresh
+    if CACHE["dt_url"] and (now - CACHE["cached_at"]) < CACHE_TTL:
+        logger.debug("Returning cached Discussion Thread (within cache TTL).")
+        return CACHE["dt_url"]
+
+    # Otherwise, fetch a fresh one
+    logger.info("Cache expired or empty. Fetching new Discussion Thread from Reddit.")
+    url = find_recent_discussion_thread()
+    CACHE["dt_url"] = url
+    CACHE["cached_at"] = now
+    return url
+
+
+def rewrite_dt_url_by_path(url: str, path: str) -> str:
+    """
+    Same logic for dt/old, dt/stream, dt/compact transformations.
+    """
+    cleaned_path = path.strip('/')
+    if cleaned_path == 'dt/old':
+        url = url.replace('www', 'old')
+    elif cleaned_path == 'dt/stream':
+        url = url.replace('reddit.com', 'reddit-stream.com')
+    elif cleaned_path == 'dt/compact':
+        url = url.replace('www', 'i')
+    return url
+
+
+# ---------------------------------------------------------------
+# HTTP Handler
+# ---------------------------------------------------------------
 class Redirect(BaseHTTPRequestHandler):
-    """Handle incoming requests"""
-
     def do_GET(self):
-        """Handle HTTP GET requests"""
+        logger.debug(f"Received GET request: Path={self.path}")
         self.send_response(302)
         try:
-            self.send_header('Location', find_dt(self.path))
+            discussion_url = get_discussion_thread_url()
+            final_url = rewrite_dt_url_by_path(discussion_url, self.path)
+            self.send_header('Location', final_url)
+            logger.debug(f"Redirecting to: {final_url}")
         except Exception:
-            self.send_header('Location', 'https://reddit.com/r/neoliberal')
+            logger.exception("Error while processing request; falling back to subreddit.")
+            self.send_header('Location', f"https://www.reddit.com/r/{DISCUSSION_SUBREDDIT}")
         self.end_headers()
 
-    def log_message(self, *_):
-        # Nginx logs are sufficient
-        pass
+    def log_message(self, format, *args):
+        # Overriding to reduce server console noise; rely on our logger
+        return
 
 
-def find_dt(path = ''):
-    """Locate the current DT using praw.
-
-    Assumes the existence of a 'neoliberal' object in outer scope
-    """
-    try:
-        url = next(dt_bot.submissions.new(limit=1)).url
-    except Exception:
-        # If we can't find the DT for whatever reason, send people to the sub
-        url = 'https://www.reddit.com/r/neoliberal'
-    if path.strip('/') == 'dt/old':
-        url = url.replace('www', 'old')
-    elif path.strip('/') == 'dt/stream':
-        url = url.replace('reddit.com', 'reddit-stream.com')
-    elif path.strip('/') == 'dt/compact':
-        url = url.replace('www', 'i')
-    return(url)
-
-
+# ---------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------
 if __name__ == "__main__":
-    """Create our Reddit instance and run the webserver indefinitely"""
+    logger.info("Starting Discussion Thread redirect server...")
+
+    # Create our Reddit instance (just needs read scope)
     reddit = praw.Reddit(
-        client_id = os.environ['client_id'],
-        client_secret = os.environ['client_secret'],
-        refresh_token = os.environ['refresh_token'],
-        user_agent = 'linux:dt_redirect:v1.1 (by /u/jenbanim)'
+        client_id=os.environ['client_id'],
+        client_secret=os.environ['client_secret'],
+        refresh_token=os.environ['refresh_token'],
+        user_agent='DiscussionThreadRedirect/1.0 (by /u/your_bot_username)'
     )
-    dt_bot = reddit.redditor(os.environ['dt_bot_username'])
+    logger.info("Reddit instance created successfully.")
+
+    logger.info(f"Will search /r/{DISCUSSION_SUBREDDIT} for 'Discussion Thread' by u/{DISCUSSION_AUTHOR} in the last 36 hours.")
+
+    logger.info("Starting HTTP server on port 8080.")
     HTTPServer(("", 8080), Redirect).serve_forever()

--- a/dt_redirect.py
+++ b/dt_redirect.py
@@ -74,8 +74,6 @@ def index(subpath=None):
         return_url = return_url.replace("www", "old")
     elif cleaned_path == "dt/stream":
         return_url = return_url.replace("reddit.com", "reddit-stream.com")
-    elif cleaned_path == "dt/compact":
-        return_url = return_url.replace("www", "i")
 
     return redirect(return_url, code=302)
 

--- a/dt_redirect.py
+++ b/dt_redirect.py
@@ -17,7 +17,6 @@ reddit = praw.Reddit(
 
 reddit.read_only = True
 
-
 # Cache structure: store the latest discussion link and when it was posted
 cached_discussion = {
     "url": None,         # e.g., "/r/something/comments/..."

--- a/dt_redirect.py
+++ b/dt_redirect.py
@@ -1,165 +1,85 @@
-import time
-import logging
-import os
-from http.server import HTTPServer, BaseHTTPRequestHandler
-from datetime import datetime, timedelta, timezone
+#!/usr/bin/env python3
+
+from flask import Flask, redirect
 import praw
+import os
+from datetime import datetime, timedelta, timezone
 
-# ---------------------------------------------------------------
-# Setup Logging
-# ---------------------------------------------------------------
-LOG_LEVEL = os.environ.get("LOG_LEVEL", "WARNING").upper()
-logging.basicConfig(
-    level=getattr(logging, LOG_LEVEL, logging.WARNING),
-    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s"
+app = Flask(__name__)
+
+# Configure PRAW
+reddit = praw.Reddit(
+    client_id = os.environ['client_id'],
+    client_secret = os.environ['client_secret'],
+    refresh_token = os.environ['refresh_token'],
+    user_agent = 'linux:dt_redirect:v1.2 (by /u/jenbanim)'
 )
-logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------
-# We'll search the public subreddit /r/neoliberal for recent posts (last 36 hours).
-# Then we check if they are by jobautomator, containing "Discussion Thread".
-DISCUSSION_AUTHOR = os.environ.get("DISCUSSION_AUTHOR", "jobautomator")
-DISCUSSION_SUBREDDIT = os.environ.get("DISCUSSION_SUBREDDIT", "neoliberal")
+reddit.read_only = True
 
-# We'll keep a simple cache to avoid hitting Reddit's API on every request.
-CACHE = {
-    "dt_url": None,             # The last known Discussion Thread URL
-    "cached_at": 0.0,           # When we last fetched it (Unix timestamp)
+
+# Cache structure: store the latest discussion link and when it was posted
+cached_discussion = {
+    "url": None,         # e.g., "/r/something/comments/..."
+    "created_utc": None  # timestamp of creation in UTC
 }
 
-# 36 hours in seconds
-TIME_WINDOW_SECONDS = 36 * 3600
-
-# We'll say once we fetch, we won't refetch for another X seconds (e.g., 15 min).
-CACHE_TTL = 15 * 60  # 15 minutes
-
-
-def find_recent_discussion_thread() -> str:
+def find_latest_discussion():
     """
-    Search /r/neoliberal for posts from the last 36 hours,
-    posted by DISCUSSION_AUTHOR, containing 'Discussion Thread' in the title.
-
-    Returns:
-        str: The URL of the most recent matching post,
-             or fallback to https://www.reddit.com/r/neoliberal if none is found.
+    Return the most recent submission from u/jobautomator whose title
+    contains 'Discussion Thread'. Returns a PRAW Submission object or None.
     """
-    logger.info("Searching subreddit for Discussion Thread...")
+    # Grab up to 10 newest submissions to be safe
+    for submission in reddit.redditor("jobautomator").submissions.new(limit=10):
+        if "Discussion Thread" in submission.title:
+            return submission
+    return None
 
-    # We'll figure out the cutoff time in Unix seconds
-    cutoff = time.time() - TIME_WINDOW_SECONDS
+def is_cache_expired():
 
-    try:
-        subreddit = reddit.subreddit(DISCUSSION_SUBREDDIT)
+    if cached_discussion["created_utc"] is None:
+        return True
 
-        # We fetch up to 100 newest submissions to see if there's a match
-        # (Adjust limit if needed)
-        matches = []
-        for submission in subreddit.new(limit=100):
-            # If the post is older than 36 hours, no need to consider it
-            if submission.created_utc < cutoff:
-                continue
+    creation_time = datetime.fromtimestamp(cached_discussion["created_utc"], tz=timezone.utc)
+    now = datetime.now(timezone.utc)
+    return (now - creation_time) >= timedelta(hours=24)
 
-            # Check if author & title match
-            if (
-                submission.author
-                and submission.author.name.lower() == DISCUSSION_AUTHOR.lower()
-                and "discussion thread" in submission.title.lower()
-            ):
-                matches.append(submission)
-
-        # Sort matched posts by creation time descending
-        matches.sort(key=lambda s: s.created_utc, reverse=True)
-
-        if matches:
-            # The first item is the most recent match
-            most_recent = matches[0]
-            logger.info(
-                f"Found a Discussion Thread by u/{DISCUSSION_AUTHOR}: "
-                f"'{most_recent.title}' -> {most_recent.url} "
-                f"(created_utc={most_recent.created_utc})"
-            )
-            return most_recent.url
-        else:
-            logger.warning("No matching Discussion Thread found in the last 36 hours.")
-            return f"https://www.reddit.com/r/{DISCUSSION_SUBREDDIT}"
-    except Exception as e:
-        logger.exception(f"Failed to search the subreddit. Using fallback. Error: {e}")
-        return f"https://www.reddit.com/r/{DISCUSSION_SUBREDDIT}"
-
-
-def get_discussion_thread_url() -> str:
+def get_discussion_link():
     """
-    Return a cached Discussion Thread URL if fresh,
-    otherwise fetch it from Reddit using find_recent_discussion_thread().
+    If the cache is empty or the cached thread is 24+ hours old, query
+    Reddit for a new Discussion Thread. If found, update the cache.
+    Otherwise, keep returning the old link (if it exists).
     """
-    now = time.time()
-    # Check if our cache is still fresh
-    if CACHE["dt_url"] and (now - CACHE["cached_at"]) < CACHE_TTL:
-        logger.debug("Returning cached Discussion Thread (within cache TTL).")
-        return CACHE["dt_url"]
+    if cached_discussion["url"] is None or is_cache_expired():
+        new_discussion = find_latest_discussion()
+        if new_discussion:
+            # Found a new thread (or at least a valid Discussion Thread),
+            # so update the cache with the new link
+            cached_discussion["url"] = new_discussion.permalink
+            cached_discussion["created_utc"] = new_discussion.created_utc
+        # If nothing new was found, either keep returning the old one
+        # or remain None if no old link exists
+    return cached_discussion["url"]
 
-    # Otherwise, fetch a fresh one
-    logger.info("Cache expired or empty. Fetching new Discussion Thread from Reddit.")
-    url = find_recent_discussion_thread()
-    CACHE["dt_url"] = url
-    CACHE["cached_at"] = now
-    return url
+@app.route("/")
+@app.route("/<path:subpath>")
+def index(subpath=None):
+    link = get_discussion_link()
+    if not link:
+        # If we have no valid link, fallback to the subreddit homepage
+        return redirect("https://www.reddit.com/r/neoliberal", code=302)
 
+    return_url = "https://www.reddit.com" + link
+    cleaned_path = (subpath or "").strip("/")
+    if cleaned_path == "dt/old":
+        return_url = return_url.replace("www", "old")
+    elif cleaned_path == "dt/stream":
+        return_url = return_url.replace("reddit.com", "reddit-stream.com")
+    elif cleaned_path == "dt/compact":
+        return_url = return_url.replace("www", "i")
 
-def rewrite_dt_url_by_path(url: str, path: str) -> str:
-    """
-    Same logic for dt/old, dt/stream, dt/compact transformations.
-    """
-    cleaned_path = path.strip('/')
-    if cleaned_path == 'dt/old':
-        url = url.replace('www', 'old')
-    elif cleaned_path == 'dt/stream':
-        url = url.replace('reddit.com', 'reddit-stream.com')
-    elif cleaned_path == 'dt/compact':
-        url = url.replace('www', 'i')
-    return url
+    return redirect(return_url, code=302)
 
-
-# ---------------------------------------------------------------
-# HTTP Handler
-# ---------------------------------------------------------------
-class Redirect(BaseHTTPRequestHandler):
-    def do_GET(self):
-        logger.debug(f"Received GET request: Path={self.path}")
-        self.send_response(302)
-        try:
-            discussion_url = get_discussion_thread_url()
-            final_url = rewrite_dt_url_by_path(discussion_url, self.path)
-            self.send_header('Location', final_url)
-            logger.debug(f"Redirecting to: {final_url}")
-        except Exception:
-            logger.exception("Error while processing request; falling back to subreddit.")
-            self.send_header('Location', f"https://www.reddit.com/r/{DISCUSSION_SUBREDDIT}")
-        self.end_headers()
-
-    def log_message(self, format, *args):
-        # Overriding to reduce server console noise; rely on our logger
-        return
-
-
-# ---------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------
 if __name__ == "__main__":
-    logger.info("Starting Discussion Thread redirect server...")
-
-    # Create our Reddit instance (just needs read scope)
-    reddit = praw.Reddit(
-        client_id=os.environ['client_id'],
-        client_secret=os.environ['client_secret'],
-        refresh_token=os.environ['refresh_token'],
-        user_agent='DiscussionThreadRedirect/1.0 (by /u/your_bot_username)'
-    )
-    logger.info("Reddit instance created successfully.")
-
-    logger.info(f"Will search /r/{DISCUSSION_SUBREDDIT} for 'Discussion Thread' by u/{DISCUSSION_AUTHOR} in the last 36 hours.")
-
-    logger.info("Starting HTTP server on port 8080.")
-    HTTPServer(("", 8080), Redirect).serve_forever()
+    # Run on port 8080
+    app.run(host="0.0.0.0", port=8080)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-praw==7.5.0
+praw
+Flask
+gunicorn


### PR DESCRIPTION
This PR does a few things

1. Use Flask+Gunicorn instead of Python's HTTP server, which is [not recommended for production](https://docs.python.org/3/library/http.server.html#http-server-security). Flask (as a WSGI app) and gunicorn (as the WSGI server) should be more secure by default, and is apparently a common python backend setup. I couldn't find many examples of other code using http.server, but personally I like using the industry standard stuff when possible to outsource the security bits to others.
2. Docker - self explanatory. Added the line for running it in the README
3. Cache DT URLs until the last URL is 24 hours old, then start checking for a new one. Until the new one is found, return the old URL but check on every request for a new one.
4. Remove the /dt/compact subpath - reddit deprecated it, so no need to support that here

Note, I set it to two workers in Gunicorn - I'm getting some weird timeouts on my desktop testing this but I'm chalking that up to it not being behind nginx which should handle some timeouts and such. Either way, the two workers should prevent timeouts from being a problem.

Currently using the default timeout for Gunicorn, 30s, which should be plenty but perhaps the reddit API is slower sometimes. We can adjust that with --timeout=X in the Gunicorn launch options in the Dockerfile if necessary

Draft so that I can let it run for a bit on my end to check for caching related bugs etc